### PR TITLE
Patch swagger-scala-module to use shaded jackson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+lib/*
 
 # Scala-IDE specific
 .scala_dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -4,40 +4,21 @@ import sbt._
 import Keys._
 import Defaults._
 
-organization := "io.swagger"
+organization := "__foursquare_shaded__.io.swagger"
 
-version := "1.0.7-SNAPSHOT"
+version := "1.0.6-fs0"
 
 scalaVersion := "2.11.12"
 
-crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.6", "2.13.1")
-
-organizationHomepage in ThisBuild := Some(url("http://swagger.io"))
-
-scalacOptions in ThisBuild ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked")  
-
-publishMavenStyle in ThisBuild := true
-
-publishArtifact in Test := false
-
-pomIncludeRepository := { x => false }
-
 libraryDependencies ++= Seq(
-  "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "io.swagger" % "swagger-core" % "1.5.24",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.10",
-  "junit" % "junit" % "4.12" % "test"
+  "org.scala-lang" % "scala-reflect" % scalaVersion.value exclude("com.google.guava", "guava"),
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test" exclude("com.google.guava", "guava"),
+  "junit" % "junit" % "4.12" % "test" exclude("com.google.guava", "guava"),
 )
 
-publishTo := {
-  if (version.value.trim.endsWith("SNAPSHOT"))
-    Some("Sonatype Nexus Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots")
-  else
-    Some("Sonatype Nexus Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-}
-
-credentials in ThisBuild += Credentials (Path.userHome / ".ivy2" / ".credentials")
+// NOTE(ssoman): If re-patching, you will need to drop copies of our shaded jackson jar, jackson-module-scala jar
+// and shaded swagger jar into the repo's top-level 'lib' directory for sbt to find them.
+unmanagedBase := file("lib")
 
 resolvers in ThisBuild ++= Seq(
   Resolver.mavenLocal,
@@ -46,40 +27,3 @@ resolvers in ThisBuild ++= Seq(
   Resolver.sonatypeRepo("releases"),
   Resolver.sonatypeRepo("snapshots")
 )
-
-publishMavenStyle := true
-
-publishArtifact in Test := false
-
-pomIncludeRepository := { x => false }
-
-credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
-
-homepage := Some(new URL("https://github.com/swagger-api/swagger-scala-module"))
-
-parallelExecution in Test := false
-
-startYear := Some(2014)
-
-licenses := Seq(("Apache License 2.0", new URL("http://www.apache.org/licenses/LICENSE-2.0.html")))
-
-pomExtra := {
-  pomExtra.value ++ Group(
-    <scm>
-      <connection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</connection>
-      <developerConnection>scm:git:git@github.com:swagger-api/swagger-scala-module.git</developerConnection>
-      <url>https://github.com/swagger-api/swagger-scala-module</url>
-    </scm>
-      <issueManagement>
-        <system>github</system>
-        <url>https://github.com/swagger-api/swagger-scala-module/issues</url>
-      </issueManagement>
-      <developers>
-        <developer>
-          <id>fehguy</id>
-          <name>Tony Tam</name>
-          <email>fehguy@gmail.com</email>
-        </developer>
-      </developers>
-  )
-}

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ version := "1.0.6-fs0"
 
 scalaVersion := "2.11.12"
 
+crossScalaVersions := Seq("2.10.6", scalaVersion.value, "2.12.6", "2.13.1")
+
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value exclude("com.google.guava", "guava"),
   "org.scalatest" %% "scalatest" % "3.0.8" % "test" exclude("com.google.guava", "guava"),

--- a/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
+++ b/src/main/scala/io/swagger/scala/converter/SwaggerScalaModelConverter.scala
@@ -4,8 +4,8 @@ import java.lang.annotation.Annotation
 import java.lang.reflect.Type
 import java.util.Iterator
 
-import com.fasterxml.jackson.databind.`type`.ReferenceType
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import __foursquare_shaded__.com.fasterxml.jackson.databind.`type`.ReferenceType
+import __foursquare_shaded__.com.fasterxml.jackson.module.scala.DefaultScalaModule
 import io.swagger.converter._
 import io.swagger.models.Model
 import io.swagger.models.properties._


### PR DESCRIPTION
There are a handful of steps involved here:

- add our shaded core jackson-fatjar, jackson-module-scala and shaded swagger jars to the repo's top-level lib directory (they are unmanaged dependencies in sbt's eyes)
- update build configuration to ban upstream jackson jars
- update jackson imports to use their shaded variants
- compile
- once everything compiles, comment out the upstream jackson
- excludes
- run tests
- uncomment the upstream jackson excludes
- bump the patch version and publish the shaded finatra jars
- test using the shaded jars locally
- upload the jar to artifactory. 
- make a new branch on our github fork off the upstream release tag (call it something like 1.0.6-fs), open a pr against that or review, then merge your changes and push a new git tag for the patch release

in sbt, run show test:fullClasspath and verify it shows no
versions of jackson other than our shaded fat jar